### PR TITLE
excl fsevents from optimizeDeps

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -12,4 +12,7 @@ export default defineNuxtConfig({
     ],
     '@nuxtjs/tailwindcss',
   ],
+  vite: {
+    optimizeDeps: { exclude: ["fsevents"] }
+  }
 })


### PR DESCRIPTION
upgrading to the latest version of Nuxt (with its dependencies), you can have this issue:
```
node_modules/fsevents/fsevents.js:13:23: ERROR: No loader is configured for ".node" files: node_modules/fsevents/fsevents.nod
```
In this case you can prevent the error with:
```
  vite: {
    optimizeDeps: { exclude: ["fsevents"] }
  }
```
in the nuxt config